### PR TITLE
ci: fix CORS deployment with semicolon separator

### DIFF
--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -47,4 +47,4 @@ jobs:
           image: gcr.io/${{ env.PROJECT_ID }}/${{ env.SERVICE_NAME }}:${{ github.sha }}
           env_vars: |
             ENVIRONMENT=production
-            CORS_ORIGINS="${{ vars.CORS_ORIGINS }}"
+            CORS_ORIGINS=${{ vars.CORS_ORIGINS }}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -23,7 +23,7 @@ const app = new Elysia()
   .use(
     cors({
       origin: process.env.CORS_ORIGINS
-        ? process.env.CORS_ORIGINS.split(',').map((o) => o.trim())
+        ? process.env.CORS_ORIGINS.split(';').map((o) => o.trim())
         : '*',
     }),
   )


### PR DESCRIPTION
## Description
This PR resolves the persistent CORS issues by switching to a semicolon (`;`) separator for the `CORS_ORIGINS` environment variable.

### Key Changes
- **Server**: Simplified `server/src/server.ts` to split origins strictly by the semicolon character (`;`).
- **Workflow**: Reverted the quotes in `deploy-server.yml` to allow the GitHub Action to pass the variable string directly to Cloud Run without formatting errors.

### Action Required
Please ensure the `CORS_ORIGINS` variable in GitHub Actions is configured as a single line with items separated by semicolons (e.g., `https://site1.com;https://site2.com`).