### PR TITLE
feat: implement board session expiration and admin grace period

### DIFF
--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -48,3 +48,5 @@ jobs:
           env_vars: |
             ENVIRONMENT=production
             CORS_ORIGINS=${{ vars.CORS_ORIGINS }}
+            SESSION_TIME_LIMIT=${{ vars.SESSION_TIME_LIMIT }}
+            ADMIN_GRACE_SECONDS=${{ vars.ADMIN_GRACE_SECONDS }}

--- a/server/src/modules/board/application/useCases/JoinBoardUseCase.ts
+++ b/server/src/modules/board/application/useCases/JoinBoardUseCase.ts
@@ -9,6 +9,7 @@ import type { UserSessionManager } from '../../../user/application/UserSessionMa
 import type { IWebSocketClient } from '../../../shared/domain/IWebSocketClient'
 import NotFoundError from '../../../shared/domain/errors/NotFoundError'
 import type { JoinBoardDTO } from '../dtos/JoinBoardDTO'
+import { I18nService } from '../../../shared/infrastructure/services/I18nService'
 
 export class JoinBoardUseCase {
   constructor(
@@ -18,6 +19,7 @@ export class JoinBoardUseCase {
     private readonly hashService: IHashService,
     private readonly logService: ILogService,
     private readonly sessionManager: UserSessionManager,
+    private readonly i18n: I18nService = new I18nService(),
   ) {}
 
   async execute(ws: IWebSocketClient, data: JoinBoardDTO): Promise<void> {
@@ -35,7 +37,12 @@ export class JoinBoardUseCase {
     }
 
     if (!this.hashService.verify(data.password, board.passwordHash)) {
-      ws.close(4001, 'Invalid password')
+      ws.close(4001, this.i18n.t('ws_close.invalid_password'))
+      return
+    }
+
+    if (board.isExpired) {
+      ws.close(4002, this.i18n.t('ws_close.session_expired'))
       return
     }
 

--- a/server/src/modules/board/application/useCases/LeaveBoardUseCase.ts
+++ b/server/src/modules/board/application/useCases/LeaveBoardUseCase.ts
@@ -25,6 +25,14 @@ export class LeaveBoardUseCase {
     }
 
     if (roomEmpty) {
+      const board = await this.boardRepository.findById(boardId)
+      if (board.isExpired) {
+        this.logService.info(
+          `[${boardId}] Room is empty but board is expired. Keeping it for grace period.`,
+        )
+        return
+      }
+
       await this.boardRepository.delete(boardId)
       await this.noteRepository.deleteAll(boardId)
       await this.groupRepository.deleteAll(boardId)

--- a/server/src/modules/board/application/useCases/ProcessBoardMessageUseCase.ts
+++ b/server/src/modules/board/application/useCases/ProcessBoardMessageUseCase.ts
@@ -35,6 +35,13 @@ export class ProcessBoardMessageUseCase {
       return
     }
 
+    const board = await this.boardRepository.findById(boardId)
+    if (!board) return
+    if (board.isExpired) {
+      this.logService.warn(`[${boardId}] Rejected message on expired board from ${user.username}`)
+      return
+    }
+
     const noteOwnershipOps = new Set([
       WsMsgType.NoteEdit,
       WsMsgType.NoteResize,
@@ -96,7 +103,6 @@ export class ProcessBoardMessageUseCase {
 
     await this.messageHandler.handle(boardId, msg)
 
-    const board = await this.boardRepository.findById(boardId)
     const isHidden = board?.isNotesHidden
 
     for (const client of roomClients) {

--- a/server/src/modules/board/domain/Board.ts
+++ b/server/src/modules/board/domain/Board.ts
@@ -1,8 +1,10 @@
 export class Board {
   readonly id: string
   readonly passwordHash: string
+  readonly createdAt: number
   createdBy: string
   isNotesHidden: boolean
+  isExpired: boolean
   nextZIndex: number
 
   constructor(
@@ -11,11 +13,15 @@ export class Board {
     createdBy: string,
     isNotesHidden = false,
     nextZIndex = 1,
+    createdAt = Date.now(),
+    isExpired = false,
   ) {
     this.id = id
     this.passwordHash = passwordHash
+    this.createdAt = createdAt
     this.createdBy = createdBy
     this.isNotesHidden = isNotesHidden
+    this.isExpired = isExpired
     this.nextZIndex = nextZIndex
   }
 }

--- a/server/src/modules/board/domain/services/BoardSessionTimerService.ts
+++ b/server/src/modules/board/domain/services/BoardSessionTimerService.ts
@@ -1,0 +1,29 @@
+import type { ServerConfig } from '../../../shared/domain/ServerConfig'
+
+export class BoardSessionTimerService {
+  private readonly limitSeconds: number
+  private readonly timers = new Map<string, ReturnType<typeof setTimeout>>()
+
+  constructor(config: ServerConfig) {
+    this.limitSeconds = config.sessionTimeLimitSeconds
+  }
+
+  isEnabled(): boolean {
+    return this.limitSeconds > 0
+  }
+
+  start(boardId: string, onExpire: () => void): void {
+    if (!this.isEnabled()) return
+
+    const timer = setTimeout(onExpire, this.limitSeconds * 1000)
+    this.timers.set(boardId, timer)
+  }
+
+  cancel(boardId: string): void {
+    const timer = this.timers.get(boardId)
+    if (timer !== undefined) {
+      clearTimeout(timer)
+      this.timers.delete(boardId)
+    }
+  }
+}

--- a/server/src/modules/board/infrastructure/http/boardController.ts
+++ b/server/src/modules/board/infrastructure/http/boardController.ts
@@ -4,6 +4,8 @@ import { ProcessBoardMessageUseCase } from '../../application/useCases/ProcessBo
 import { LeaveBoardUseCase } from '../../application/useCases/LeaveBoardUseCase'
 import type { IWebSocketClient } from '../../../shared/domain/IWebSocketClient'
 import { BoardMessageHandler } from '../../application/BoardMessageHandler'
+import { BoardSessionTimerService } from '../../domain/services/BoardSessionTimerService'
+import type { ServerConfig } from '../../../shared/domain/ServerConfig'
 import { UserSessionManager } from '../../../user/application/UserSessionManager'
 import type { IBoardRepository } from '../../domain/repositories/IBoardRepository'
 import type { INoteRepository } from '../../domain/repositories/INoteRepository'
@@ -30,6 +32,7 @@ interface Deps {
   groupRepository: INoteGroupRepository
   hashService: IHashService
   logService: ILogService
+  config: ServerConfig
 }
 
 export function boardController({
@@ -38,9 +41,11 @@ export function boardController({
   groupRepository,
   hashService,
   logService,
+  config,
 }: Deps) {
   const messageHandler = new BoardMessageHandler(boardRepository, noteRepository, groupRepository)
   const sessionManager = new UserSessionManager(logService)
+  const boardSessionTimer = new BoardSessionTimerService(config)
   const jsonExportBoardUseCase = new JsonExportBoardUseCase(
     boardRepository,
     noteRepository,
@@ -77,6 +82,58 @@ export function boardController({
     sessionManager,
   )
 
+  /** In-memory tracking of grace period timers (boardId → timer) */
+  const gracePeriodTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+  async function deleteBoardData(boardId: string): Promise<void> {
+    try {
+      await boardRepository.delete(boardId)
+      await noteRepository.deleteAll(boardId)
+      await groupRepository.deleteAll(boardId)
+      logService.info(`[${boardId}] Board data deleted after session expiry grace period`)
+    } catch (e) {
+      logService.error(`[${boardId}] Error deleting board data after grace period: ${e}`)
+    }
+  }
+
+  function startGracePeriod(boardId: string): void {
+    logService.info(
+      `[${boardId}] Starting grace period of ${config.adminGraceSeconds}s before data deletion`,
+    )
+    const timer = setTimeout(async () => {
+      gracePeriodTimers.delete(boardId)
+      await deleteBoardData(boardId)
+    }, config.adminGraceSeconds * 1000)
+    gracePeriodTimers.set(boardId, timer)
+  }
+
+  function cancelGracePeriod(boardId: string): void {
+    const timer = gracePeriodTimers.get(boardId)
+    if (timer !== undefined) {
+      clearTimeout(timer)
+      gracePeriodTimers.delete(boardId)
+    }
+  }
+
+  async function onSessionExpired(boardId: string): Promise<void> {
+    logService.info(`[${boardId}] Session time limit reached`)
+
+    let board
+    try {
+      board = await boardRepository.findById(boardId)
+    } catch {
+      return
+    }
+
+    board.isExpired = true
+    await boardRepository.save(board)
+
+    const expiredMsg: WsMessage = { type: WsMsgType.SessionExpired }
+    sessionManager.broadcastToRoom(boardId, expiredMsg)
+
+    startGracePeriod(boardId)
+  }
+
   return new Elysia({ prefix: '/board' })
     .ws('/ws', {
       query: WebSocketQuerySchema,
@@ -107,6 +164,8 @@ export function boardController({
         } catch (e) {
           if (e instanceof NotFoundError) {
             await boardRepository.save(new Board(boardId, hashService.hash(password), clientId))
+
+            boardSessionTimer.start(boardId, () => onSessionExpired(boardId))
 
             return ApiResponse.success({ boardId })
           }
@@ -143,6 +202,9 @@ export function boardController({
     .get(
       '/:id/export',
       async ({ params: { id }, query }) => {
+        // Exporting cancels the grace-period auto-delete so admin data is preserved
+        cancelGracePeriod(id)
+
         let exportedData
         switch (query.format) {
           case 'json':

--- a/server/src/modules/shared/domain/ServerConfig.ts
+++ b/server/src/modules/shared/domain/ServerConfig.ts
@@ -1,0 +1,22 @@
+export class ServerConfig {
+  readonly port: number
+  readonly corsOrigins: string | string[]
+  readonly sessionTimeLimitSeconds: number
+  readonly adminGraceSeconds: number
+
+  constructor() {
+    this.port = Number(process.env.PORT) || 3001
+
+    this.corsOrigins = process.env.CORS_ORIGINS
+      ? process.env.CORS_ORIGINS.split(';').map((o) => o.trim())
+      : '*'
+
+    const sessionLimit = process.env.SESSION_TIME_LIMIT
+    const parsedSessionLimit = sessionLimit !== undefined ? parseInt(sessionLimit, 10) : -1
+    this.sessionTimeLimitSeconds = isNaN(parsedSessionLimit) ? -1 : parsedSessionLimit
+
+    const adminGrace = process.env.ADMIN_GRACE_SECONDS
+    const parsedAdminGrace = adminGrace !== undefined ? parseInt(adminGrace, 10) : 60
+    this.adminGraceSeconds = isNaN(parsedAdminGrace) ? 60 : parsedAdminGrace
+  }
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -12,6 +12,9 @@ import { globalErrorHandler } from './modules/shared/infrastructure/http/globalE
 import { ApiResponse } from '@shared/types/api'
 import { i18n } from './modules/shared/infrastructure/services/i18nPlugin'
 import { languages } from '@shared/i18n'
+import { ServerConfig } from './modules/shared/domain/ServerConfig'
+
+const config = new ServerConfig()
 
 const boardRepository = new MemoryBoardRepository()
 const noteRepository = new MemoryNoteRepository()
@@ -22,9 +25,7 @@ const logService = new ConsoleLogService()
 const app = new Elysia()
   .use(
     cors({
-      origin: process.env.CORS_ORIGINS
-        ? process.env.CORS_ORIGINS.split(';').map((o) => o.trim())
-        : '*',
+      origin: config.corsOrigins,
     }),
   )
   .use(openapi({ path: '/docs' }))
@@ -40,8 +41,13 @@ const app = new Elysia()
       groupRepository,
       hashService,
       logService,
+      config,
     }),
   )
-  .listen(Number(process.env.PORT) || 3001)
+  .listen(config.port)
 
 logService.info(`Open Retro WS Server running on ws://localhost:${app.server?.port}`)
+logService.info(
+  `Session time limit: ${config.sessionTimeLimitSeconds > 0 ? config.sessionTimeLimitSeconds + 's' : 'Disabled'}`,
+)
+logService.info(`Admin grace period: ${config.adminGraceSeconds}s`)

--- a/shared/i18n/locales/en.json
+++ b/shared/i18n/locales/en.json
@@ -84,5 +84,17 @@
   "notifications": {
     "import_success": "Board imported successfully",
     "invalid_json": "File is not a valid JSON"
+  },
+  "session_expired": {
+    "title": "Session time limit reached",
+    "description": "This board has reached its maximum session time and is now locked.",
+    "go_back": "Go Back",
+    "export_board": "Export Board",
+    "admin_warning": "You have {seconds}s to export the board before all data is permanently erased.",
+    "data_erased": "Board data has been permanently erased."
+  },
+  "ws_close": {
+    "invalid_password": "Invalid password",
+    "session_expired": "Session expired"
   }
 }

--- a/shared/i18n/locales/es.json
+++ b/shared/i18n/locales/es.json
@@ -84,5 +84,17 @@
   "notifications": {
     "import_success": "Tablero importado correctamente",
     "invalid_json": "El archivo no es un JSON válido"
+  },
+  "session_expired": {
+    "title": "Tiempo límite de sesión alcanzado",
+    "description": "Este tablero alcanzó su tiempo máximo de sesión y ahora está bloqueado.",
+    "go_back": "Volver",
+    "export_board": "Exportar tablero",
+    "admin_warning": "Tenés {seconds}s para exportar el tablero antes de que todos los datos sean eliminados permanentemente.",
+    "data_erased": "Los datos del tablero fueron eliminados permanentemente."
+  },
+  "ws_close": {
+    "invalid_password": "Contraseña incorrecta",
+    "session_expired": "Sesión expirada"
   }
 }

--- a/shared/types/board.ts
+++ b/shared/types/board.ts
@@ -55,6 +55,7 @@ export enum WsMsgType {
   UsersSync = 'users:sync',
   UserJoin = 'user:join',
   UserLeave = 'user:leave',
+  SessionExpired = 'session:expired',
 }
 
 export type WsMessage =
@@ -76,3 +77,4 @@ export type WsMessage =
   | { type: WsMsgType.UsersSync; users: ConnectedUser[] }
   | { type: WsMsgType.UserJoin; user: ConnectedUser }
   | { type: WsMsgType.UserLeave; userId: string }
+  | { type: WsMsgType.SessionExpired }

--- a/web-client/src/components/BoardCanvas.vue
+++ b/web-client/src/components/BoardCanvas.vue
@@ -6,6 +6,7 @@ import StickyNote from './StickyNote.vue'
 import NoteGroup from './NoteGroup.vue'
 import ToolBar from './ToolBar.vue'
 import UsersSidebar from './UsersSidebar.vue'
+import SessionExpiredModal from './SessionExpiredModal.vue'
 import { useWebSocket } from '../composables/useWebSocket'
 import { useToast } from '../composables/useToast'
 import { useI18n } from 'vue-i18n'
@@ -34,13 +35,14 @@ const groups = ref<Group[]>([])
 const connectedUsers = ref<ConnectedUser[]>([])
 const isNotesHidden = ref(false)
 const boardCreator = ref<string | null>(null)
+const isSessionExpired = ref(false)
 const fileInput = ref<HTMLInputElement | null>(null)
 let topZ = 1
 
 const navigator = new Navigator(useRouter())
 const { t } = useI18n()
 const { show: showToast } = useToast()
-const { send, onMessage, isConnected, wsError } = useWebSocket(wsUrl)
+const { send, onMessage, isConnected, wsError, disconnect } = useWebSocket(wsUrl)
 
 watch(wsError, (err) => {
   if (err === 'auth') {
@@ -140,6 +142,10 @@ onMessage((msg) => {
       break
     case WsMsgType.UserLeave:
       connectedUsers.value = connectedUsers.value.filter((u) => u.id !== msg.userId)
+      break
+    case WsMsgType.SessionExpired:
+      isSessionExpired.value = true
+      disconnect()
       break
   }
 })
@@ -398,6 +404,14 @@ function onBoardMouseDown(event: MouseEvent) {
       </div>
     </div>
   </div>
+
+  <SessionExpiredModal
+    v-if="isSessionExpired"
+    :is-admin="boardCreator === myId"
+    :server-url="props.serverUrl"
+    :board-id="props.boardId"
+    @go-back="navigator.backToBoardSetup()"
+  />
 </template>
 
 <style scoped>

--- a/web-client/src/components/SessionExpiredModal.vue
+++ b/web-client/src/components/SessionExpiredModal.vue
@@ -1,0 +1,322 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { BoardService } from '@/services/api/boardService'
+
+const props = defineProps<{
+  isAdmin: boolean
+  serverUrl: string
+  boardId: string
+}>()
+
+const emit = defineEmits<{
+  'go-back': []
+}>()
+
+const { t } = useI18n()
+
+const GRACE_SECONDS = 60
+const countdown = ref(GRACE_SECONDS)
+const isDataErased = ref(false)
+let countdownInterval: ReturnType<typeof setInterval> | null = null
+
+const adminWarning = computed(() =>
+  t('session_expired.admin_warning', { seconds: countdown.value }),
+)
+
+onMounted(() => {
+  if (!props.isAdmin) return
+
+  countdownInterval = setInterval(() => {
+    countdown.value -= 1
+    if (countdown.value <= 0) {
+      isDataErased.value = true
+      stopCountdown()
+    }
+  }, 1000)
+})
+
+onUnmounted(stopCountdown)
+
+function stopCountdown() {
+  if (countdownInterval !== null) {
+    clearInterval(countdownInterval)
+    countdownInterval = null
+  }
+}
+
+function exportBoard() {
+  const boardService = new BoardService(props.serverUrl)
+  boardService.exportBoard({
+    boardId: props.boardId,
+    onSuccess: (data) => {
+      stopCountdown()
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `${props.boardId}.json`
+      a.click()
+      URL.revokeObjectURL(url)
+    },
+  })
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <!-- No @click.self to prevent closing. This is intentionally blocking. -->
+    <div class="expired-backdrop">
+      <div class="expired-card">
+        <!-- Icon -->
+        <div class="icon-wrap">
+          <svg
+            class="clock-icon"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <polyline points="12 6 12 12 16 14" />
+          </svg>
+        </div>
+
+        <!-- Text -->
+        <h2 class="title">{{ t('session_expired.title') }}</h2>
+        <p class="description">{{ t('session_expired.description') }}</p>
+
+        <!-- Admin-only section -->
+        <div v-if="isAdmin" class="admin-section">
+          <div v-if="!isDataErased" class="admin-warning">
+            <span class="countdown-badge">{{ countdown }}s</span>
+            <p class="warning-text">{{ adminWarning }}</p>
+          </div>
+          <p v-else class="erased-text">{{ t('session_expired.data_erased') }}</p>
+        </div>
+
+        <!-- Actions -->
+        <div class="actions">
+          <button v-if="isAdmin && !isDataErased" class="btn btn-export" @click="exportBoard">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+              <polyline points="7 10 12 15 17 10" />
+              <line x1="12" y1="15" x2="12" y2="3" />
+            </svg>
+            {{ t('session_expired.export_board') }}
+          </button>
+
+          <button class="btn btn-back" @click="emit('go-back')">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <line x1="19" y1="12" x2="5" y2="12" />
+              <polyline points="12 19 5 12 12 5" />
+            </svg>
+            {{ t('session_expired.go_back') }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.expired-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.85);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  padding: 24px;
+  animation: fadeIn 0.35s ease-out;
+}
+
+.expired-card {
+  background: var(--color-background-soft);
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  border-radius: 24px;
+  padding: 48px 40px;
+  max-width: 520px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  box-shadow:
+    0 0 0 1px rgba(239, 68, 68, 0.15),
+    0 40px 80px rgba(0, 0, 0, 0.6),
+    0 0 60px rgba(239, 68, 68, 0.08);
+  animation: slideUp 0.35s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* Icon */
+.icon-wrap {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: pulse-ring 2s ease-in-out infinite;
+}
+
+.clock-icon {
+  width: 36px;
+  height: 36px;
+  color: #ef4444;
+}
+
+/* Text */
+.title {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--color-text);
+  text-align: center;
+  margin: 0;
+  line-height: 1.3;
+}
+
+.description {
+  font-size: 14px;
+  color: var(--color-muted);
+  text-align: center;
+  margin: 0;
+  line-height: 1.6;
+}
+
+/* Admin section */
+.admin-section {
+  width: 100%;
+  background: rgba(239, 68, 68, 0.07);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  border-radius: 12px;
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.admin-warning {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.countdown-badge {
+  flex-shrink: 0;
+  background: rgba(239, 68, 68, 0.2);
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  border-radius: 8px;
+  padding: 4px 10px;
+  font-size: 13px;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  color: #ef4444;
+  min-width: 48px;
+  text-align: center;
+}
+
+.warning-text {
+  font-size: 13px;
+  color: rgba(239, 68, 68, 0.85);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.erased-text {
+  font-size: 13px;
+  color: var(--color-muted);
+  margin: 0;
+  text-align: center;
+  font-style: italic;
+}
+
+/* Actions */
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+  margin-top: 4px;
+}
+
+.btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  padding: 13px 20px;
+  border: none;
+  border-radius: 12px;
+  font-size: 14px;
+  font-weight: 600;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.btn svg {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.btn-export {
+  background: var(--color-primary);
+  color: #0f1117;
+}
+
+.btn-export:hover {
+  background: var(--color-primary-light);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 16px rgba(62, 175, 124, 0.35);
+}
+
+.btn-back {
+  background: var(--color-background-mute);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+}
+
+.btn-back:hover {
+  background: rgba(255, 255, 255, 0.07);
+  border-color: var(--color-border-hover);
+}
+
+/* Animations */
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(24px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes pulse-ring {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.25);
+  }
+  50% {
+    box-shadow: 0 0 0 8px rgba(239, 68, 68, 0);
+  }
+}
+</style>


### PR DESCRIPTION
### Overview
This PR implements a session time limit for retro boards to ensure efficient resource management and improve the overall board lifecycle. It includes a configurable session duration and an administrative grace period that allows creators to export data before permanent deletion.

### Key Changes
- **Server Configuration**: Introduced a centralized `ServerConfig` entity to manage environment variables like `SESSION_TIME_LIMIT` and `ADMIN_GRACE_SECONDS` with robust parsing.
- **Session expiration logic**: 
    - Implemented `BoardSessionTimerService` to handle automated board locking after a set time.
    - Added `isExpired` state to the `Board` domain model.
- **WebSocket updates**: New `session:expired` event broadcasted when a board reaches its limit, triggering a clean disconnect on the client side.
- **Grace Period & Persistence**:
    - Implemented a grace period after expiration before actual data deletion.
    - Modified `LeaveBoardUseCase` to prevent premature deletion when the last user leaves an expired board, ensuring the grace period timer is respected.
    - Exporting the board now cancels the auto-deletion timer to preserve the data if the admin chooses to save it.
- **Client UI**:
    - Created a premium `SessionExpiredModal` with countdown indicators for admins.
    - Added internationalization (i18n) support for expiration messages in English and Spanish.
- **DevOps**: Updated GitHub Actions and Docker configuration to support the new environment variables.

### Impact
- Improves server memory management by automatically cleaning up inactive/expired boards.
- Provides a clear and polished user experience when session limits are reached.
- Ensures data safety for administrators through a dedicated grace period and export functionality.