### PR TITLE
fix(web-client): point types to source and bump version to 0.0.4

### DIFF
--- a/web-client/package.json
+++ b/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-retro/web-client",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": false,
   "files": [
     "dist-lib",
@@ -9,10 +9,10 @@
   "type": "module",
   "main": "dist-lib/open-retro-web-client.umd.js",
   "module": "dist-lib/open-retro-web-client.es.js",
-  "types": "dist-lib/index.d.ts",
+  "types": "src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist-lib/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist-lib/open-retro-web-client.es.js",
       "require": "./dist-lib/open-retro-web-client.umd.js"
     },


### PR DESCRIPTION
### Overview
This PR updates the `web-client` configuration to point the type definitions directly to the source files and increments the version to `0.0.4`.

### Key Changes
- Updated `types` and `exports.types` in `web-client/package.json` to point to `src/index.ts` instead of `dist-lib/index.d.ts`.
- Bumped version from `0.0.3` to `0.0.4`.

### Impact
Resolves TypeScript resolution issues where the consumer was unable to find declarations in the `dist-lib` folder. This ensures a smoother development experience and reliable type checking when using `@open-retro/web-client`.