### PR TITLE
fix(web-client): include global styles in library build and bump version to 0.0.5

### DIFF
--- a/web-client/package.json
+++ b/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-retro/web-client",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": false,
   "files": [
     "dist-lib",

--- a/web-client/src/index.ts
+++ b/web-client/src/index.ts
@@ -1,3 +1,5 @@
+import './assets/main.css'
+
 // Core Application Layer
 export { default as App } from './App.vue'
 export { default as router } from './router/index'


### PR DESCRIPTION
## Overview
This PR ensures that global CSS variables and base styles are included in the `@open-retro/web-client` library build. This resolves an issue where the library components appeared incorrectly (missing styles, colors, and fonts) when consumed in external projects like the private SaaS repository.

## Key Changes
- **Library Entry Point**: Added `import './assets/main.css'` to `web-client/src/index.ts`. This ensures that Vite's library mode extracts all global variables and base styles into the final CSS bundle.
- **Version Bump**: Updated `@open-retro/web-client` to `0.0.5` to reflect these changes and ensure clean dependency resolution.

## Impact
- **Consistency**: The `dist-lib/web-client.css` file now includes the full design system (colors, spacing, typography).
- **Fixes**: Resolves the "look and feel" discrepancy reported when using the library components outside of the core repository.