### PR TITLE
feat(server): implement session user limit and refactor ServerConfig

### DIFF
--- a/.agents/rules/shared-module-guide.md
+++ b/.agents/rules/shared-module-guide.md
@@ -1,0 +1,6 @@
+---
+trigger: glob
+globs: shared/
+---
+
+Cada vez que se modifiquen los fuentes de shared/ (JSONs de i18n, tipos, etc.) hay que correr npm run build en ese directorio para que los cambios se propaguen.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ environment:
   ENVIRONMENT: "production"
 ```
 
+### Configuración del Servidor
+
+El servidor acepta las siguientes variables de entorno para su configuración:
+
+| Variable | Descripción | Valor por defecto |
+|---|---|---|
+| `PORT` | Puerto en el que corre el servidor | `3001` |
+| `CORS_ORIGINS` | Orígenes permitidos (separados por `;`) | `*` |
+| `SESSION_TIME_LIMIT` | Tiempo máximo en segundos para una sesión (vencimiento) | Sin límite |
+| `ADMIN_GRACE_SECONDS` | Tiempo de gracia en segundos tras el vencimiento antes de borrar datos | `60` |
+| `MAX_USERS_PER_SESSION` | Límite de usuarios conectados por tablero | Sin límite |
+
+Esto se puede configurar en el archivo `docker-compose.yml` bajo la sección `environment` del servicio `server`.
+
 ### Limpiar contenedores y volúmenes
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,10 @@ services:
     environment:
       PORT: '3001'
       ENVIRONMENT: '${ENVIRONMENT:-develop}'
+      CORS_ORIGINS: '${CORS_ORIGINS:-*}'
+      SESSION_TIME_LIMIT: '${SESSION_TIME_LIMIT:-}'
+      ADMIN_GRACE_SECONDS: '${ADMIN_GRACE_SECONDS:-60}'
+      MAX_USERS_PER_SESSION: '${MAX_USERS_PER_SESSION:-}'
     volumes:
       - ./server/src:/app/server/src
       - ./shared:/app/shared

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -19,5 +19,9 @@ WORKDIR /app/server
 
 ENV PORT=3001
 ENV ENVIRONMENT=develop
+ENV CORS_ORIGINS=*
+ENV SESSION_TIME_LIMIT=-1
+ENV ADMIN_GRACE_SECONDS=60
+ENV MAX_USERS_PER_SESSION=null
 
 CMD ["sh", "-c", "if [ \"$ENVIRONMENT\" = \"production\" ]; then bun src/bin.ts; else bun --watch src/bin.ts; fi"]

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-retro/server",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "files": [
     "dist"
   ],

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -25,11 +25,11 @@ export interface OpenRetroAppDeps {
   groupRepository?: INoteGroupRepository
   hashService?: IHashService
   logService?: ILogService
-  config?: ServerConfig
+  config: ServerConfig
 }
 
-export function createOpenRetroApp(deps: OpenRetroAppDeps = {}) {
-  const config = deps.config ?? new ServerConfig()
+export function createOpenRetroApp(deps: OpenRetroAppDeps) {
+  const { config } = deps
   const boardRepository = deps.boardRepository ?? new MemoryBoardRepository()
   const noteRepository = deps.noteRepository ?? new MemoryNoteRepository()
   const groupRepository = deps.groupRepository ?? new MemoryNoteGroupRepository()

--- a/server/src/bin.ts
+++ b/server/src/bin.ts
@@ -2,7 +2,38 @@ import { createOpenRetroApp } from './app'
 import { ServerConfig } from './modules/shared/domain/ServerConfig'
 import { ConsoleLogService } from './modules/shared/infrastructure/services/ConsoleLogService'
 
-const config = new ServerConfig()
+function loadConfig(): ServerConfig {
+  const port = Number(process.env.PORT) || 3001
+
+  const corsOrigins = process.env.CORS_ORIGINS
+    ? process.env.CORS_ORIGINS.split(';').map((o) => o.trim())
+    : '*'
+
+  const sessionLimit = process.env.SESSION_TIME_LIMIT
+  const parsedSessionLimit = sessionLimit !== undefined ? parseInt(sessionLimit, 10) : -1
+  const sessionTimeLimitSeconds = isNaN(parsedSessionLimit) ? -1 : parsedSessionLimit
+
+  const adminGrace = process.env.ADMIN_GRACE_SECONDS
+  const parsedAdminGrace = adminGrace !== undefined ? parseInt(adminGrace, 10) : 60
+  const adminGraceSeconds = isNaN(parsedAdminGrace) ? 60 : parsedAdminGrace
+
+  const maxUsers = process.env.MAX_USERS_PER_SESSION
+  let maxUsersPerSession: number | null = null
+  if (maxUsers !== undefined) {
+    const parsedMaxUsers = parseInt(maxUsers, 10)
+    maxUsersPerSession = isNaN(parsedMaxUsers) || parsedMaxUsers <= 0 ? null : parsedMaxUsers
+  }
+
+  return {
+    port,
+    corsOrigins,
+    sessionTimeLimitSeconds,
+    adminGraceSeconds,
+    maxUsersPerSession,
+  }
+}
+
+const config = loadConfig()
 const logService = new ConsoleLogService()
 
 const app = createOpenRetroApp({ config, logService })
@@ -13,3 +44,6 @@ logService.info(
   `Session time limit: ${config.sessionTimeLimitSeconds > 0 ? config.sessionTimeLimitSeconds + 's' : 'Disabled'}`,
 )
 logService.info(`Admin grace period: ${config.adminGraceSeconds}s`)
+if (config.maxUsersPerSession !== null) {
+  logService.info(`Max users per session: ${config.maxUsersPerSession}`)
+}

--- a/server/src/modules/board/application/useCases/JoinBoardUseCase.ts
+++ b/server/src/modules/board/application/useCases/JoinBoardUseCase.ts
@@ -10,6 +10,7 @@ import type { IWebSocketClient } from '../../../shared/domain/IWebSocketClient'
 import NotFoundError from '../../../shared/domain/errors/NotFoundError'
 import type { JoinBoardDTO } from '../dtos/JoinBoardDTO'
 import { I18nService } from '../../../shared/infrastructure/services/I18nService'
+import type { ServerConfig } from '../../../shared/domain/ServerConfig'
 
 export class JoinBoardUseCase {
   constructor(
@@ -19,6 +20,7 @@ export class JoinBoardUseCase {
     private readonly hashService: IHashService,
     private readonly logService: ILogService,
     private readonly sessionManager: UserSessionManager,
+    private readonly config: ServerConfig,
     private readonly i18n: I18nService = new I18nService(),
   ) {}
 
@@ -43,6 +45,14 @@ export class JoinBoardUseCase {
 
     if (board.isExpired) {
       ws.close(4002, this.i18n.t('ws_close.session_expired'))
+      return
+    }
+
+    if (
+      this.config.maxUsersPerSession !== null &&
+      this.sessionManager.getRoomUsers(data.boardId).length >= this.config.maxUsersPerSession
+    ) {
+      ws.close(4003, this.i18n.t('ws_close.session_full'))
       return
     }
 

--- a/server/src/modules/board/infrastructure/http/boardController.ts
+++ b/server/src/modules/board/infrastructure/http/boardController.ts
@@ -65,6 +65,7 @@ export function boardController({
     hashService,
     logService,
     sessionManager,
+    config,
   )
   const processBoardMessageUseCase = new ProcessBoardMessageUseCase(
     boardRepository,

--- a/server/src/modules/shared/domain/ServerConfig.ts
+++ b/server/src/modules/shared/domain/ServerConfig.ts
@@ -1,22 +1,7 @@
-export class ServerConfig {
-  readonly port: number
-  readonly corsOrigins: string | string[]
-  readonly sessionTimeLimitSeconds: number
-  readonly adminGraceSeconds: number
-
-  constructor() {
-    this.port = Number(process.env.PORT) || 3001
-
-    this.corsOrigins = process.env.CORS_ORIGINS
-      ? process.env.CORS_ORIGINS.split(';').map((o) => o.trim())
-      : '*'
-
-    const sessionLimit = process.env.SESSION_TIME_LIMIT
-    const parsedSessionLimit = sessionLimit !== undefined ? parseInt(sessionLimit, 10) : -1
-    this.sessionTimeLimitSeconds = isNaN(parsedSessionLimit) ? -1 : parsedSessionLimit
-
-    const adminGrace = process.env.ADMIN_GRACE_SECONDS
-    const parsedAdminGrace = adminGrace !== undefined ? parseInt(adminGrace, 10) : 60
-    this.adminGraceSeconds = isNaN(parsedAdminGrace) ? 60 : parsedAdminGrace
-  }
+export interface ServerConfig {
+  port: number
+  corsOrigins: string | string[]
+  sessionTimeLimitSeconds: number
+  adminGraceSeconds: number
+  maxUsersPerSession: number | null
 }

--- a/shared/i18n/index.d.ts
+++ b/shared/i18n/index.d.ts
@@ -91,6 +91,7 @@ export declare const dictionaries: {
       wrong_password: string
       access_denied: string
       reconnecting: string
+      session_full: string
     }
     notifications: {
       import_success: string
@@ -107,6 +108,7 @@ export declare const dictionaries: {
     ws_close: {
       invalid_password: string
       session_expired: string
+      session_full: string
     }
   }
   readonly es: {
@@ -200,6 +202,7 @@ export declare const dictionaries: {
       wrong_password: string
       access_denied: string
       reconnecting: string
+      session_full: string
     }
     notifications: {
       import_success: string
@@ -216,6 +219,7 @@ export declare const dictionaries: {
     ws_close: {
       invalid_password: string
       session_expired: string
+      session_full: string
     }
   }
 }

--- a/shared/i18n/locales/en.json
+++ b/shared/i18n/locales/en.json
@@ -88,7 +88,8 @@
   "connection": {
     "wrong_password": "Wrong password",
     "access_denied": "Wrong password — access denied",
-    "reconnecting": "Reconnecting..."
+    "reconnecting": "Reconnecting...",
+    "session_full": "Board is full — maximum users reached"
   },
   "notifications": {
     "import_success": "Board imported successfully",
@@ -104,6 +105,7 @@
   },
   "ws_close": {
     "invalid_password": "Invalid password",
-    "session_expired": "Session expired"
+    "session_expired": "Session expired",
+    "session_full": "This board has reached its maximum number of users"
   }
 }

--- a/shared/i18n/locales/es.json
+++ b/shared/i18n/locales/es.json
@@ -88,7 +88,8 @@
   "connection": {
     "wrong_password": "Contraseña incorrecta",
     "access_denied": "Contraseña incorrecta — acceso denegado",
-    "reconnecting": "Reconectando..."
+    "reconnecting": "Reconectando...",
+    "session_full": "El tablero está lleno — límite de usuarios alcanzado"
   },
   "notifications": {
     "import_success": "Tablero importado correctamente",
@@ -104,6 +105,7 @@
   },
   "ws_close": {
     "invalid_password": "Contraseña incorrecta",
-    "session_expired": "Sesión expirada"
+    "session_expired": "Sesión expirada",
+    "session_full": "Este tablero alcanzó el límite máximo de usuarios"
   }
 }

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-retro/shared",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "files": [
     "dist"
   ],

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-retro/web-client",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": false,
   "files": [
     "dist-lib",

--- a/web-client/src/components/BoardCanvas.vue
+++ b/web-client/src/components/BoardCanvas.vue
@@ -50,6 +50,10 @@ watch(wsError, (err) => {
     showToast(t('connection.wrong_password'))
     navigator.backToBoardSetup()
   }
+  if (err === 'session_full') {
+    showToast(t('connection.session_full'))
+    navigator.backToBoardSetup()
+  }
 })
 
 onMessage((msg) => {
@@ -469,6 +473,9 @@ function onBoardMouseDown(event: MouseEvent) {
     <div class="footer-overlay">
       <div v-if="wsError === 'auth'" class="connection-status error">
         {{ t('connection.access_denied') }}
+      </div>
+      <div v-else-if="wsError === 'session_full'" class="connection-status error">
+        {{ t('connection.session_full') }}
       </div>
       <div v-else-if="!isConnected" class="connection-status">
         {{ t('connection.reconnecting') }}

--- a/web-client/src/composables/useWebSocket.ts
+++ b/web-client/src/composables/useWebSocket.ts
@@ -1,7 +1,7 @@
 import { ref, onUnmounted } from 'vue'
 import type { WsMessage } from '@open-retro/shared/types/board'
 
-export type WsError = 'auth' | 'connection' | null
+export type WsError = 'auth' | 'session_full' | 'connection' | null
 
 export function useWebSocket(url: string) {
   const isConnected = ref(false)
@@ -32,6 +32,13 @@ export function useWebSocket(url: string) {
         wsError.value = 'auth'
         shouldReconnect = false
         console.log('[WS] Authentication failed')
+        return
+      }
+
+      if (event.code === 4003) {
+        wsError.value = 'session_full'
+        shouldReconnect = false
+        console.log('[WS] Session is full')
         return
       }
 


### PR DESCRIPTION
## Overview
This PR implements a maximum user limit per session for the Open Retro server and performs a significant refactor of the server's configuration management. These changes improve server control and user experience when a board has reached its capacity.

## Key Changes
### Server
- **Refactor `ServerConfig`**: Converted `ServerConfig` from a class to an `interface`. Environment variable parsing is now handled by a private `loadConfig` function in `bin.ts`.
- **User Limit Logic**: Added `maxUsersPerSession` to the configuration. Modified `JoinBoardUseCase` to enforce this limit by closing WebSocket connections with code `4003` and a descriptive i18n message.
- **Improved Logging**: The server now logs the active session limit and other configuration details on startup.

### Web Client
- **Session Full Handling**: Updated `useWebSocket` to handle close code `4003` as a `session_full` error.
- **UI Feedback**: `BoardCanvas.vue` now displays a specific toast and footer message when a board is full, redirecting users back to the setup page.

### Backend & DevOps
- **Docker Support**: Updated `Dockerfile` and `docker-compose.yml` to include the new environment variables (`MAX_USERS_PER_SESSION`, `CORS_ORIGINS`, `SESSION_TIME_LIMIT`, `ADMIN_GRACE_SECONDS`).
- **Documentation**: Added a "Server Configuration" section to the `README.md` documenting all available environment variables.
- **i18n**: Added `session_full` keys to English and Spanish locales.

## Impact
- Administrators can now control server load by limiting users per session.
- Developers benefit from a cleaner configuration architecture.
- Users receive clear feedback when they are unable to join a board due to capacity limits.
