### PR TITLE
feat(server): add API documentation toggle and version bump

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       SESSION_TIME_LIMIT: '${SESSION_TIME_LIMIT:-}'
       ADMIN_GRACE_SECONDS: '${ADMIN_GRACE_SECONDS:-60}'
       MAX_USERS_PER_SESSION: '${MAX_USERS_PER_SESSION:-}'
+      SHOW_API_DOCS: '${SHOW_API_DOCS:-true}'
     volumes:
       - ./server/src:/app/server/src
       - ./shared:/app/shared

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -23,5 +23,6 @@ ENV CORS_ORIGINS=*
 ENV SESSION_TIME_LIMIT=-1
 ENV ADMIN_GRACE_SECONDS=60
 ENV MAX_USERS_PER_SESSION=null
+ENV SHOW_API_DOCS=true
 
 CMD ["sh", "-c", "if [ \"$ENVIRONMENT\" = \"production\" ]; then bun src/bin.ts; else bun --watch src/bin.ts; fi"]

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-retro/server",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "files": [
     "dist"
   ],

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -36,13 +36,17 @@ export function createOpenRetroApp(deps: OpenRetroAppDeps) {
   const hashService = deps.hashService ?? new BunHashService()
   const logService = deps.logService ?? new ConsoleLogService()
 
-  return new Elysia()
-    .use(
-      cors({
-        origin: config.corsOrigins,
-      }),
-    )
-    .use(openapi({ path: '/docs' }))
+  let app = new Elysia().use(
+    cors({
+      origin: config.corsOrigins,
+    }),
+  )
+
+  if (config.showApiDocs) {
+    app = app.use(openapi({ path: '/docs' }))
+  }
+
+  return app
     .use(i18n)
     .use(globalErrorHandler)
     .get('/ping', () => ApiResponse.success())

--- a/server/src/bin.ts
+++ b/server/src/bin.ts
@@ -24,12 +24,15 @@ function loadConfig(): ServerConfig {
     maxUsersPerSession = isNaN(parsedMaxUsers) || parsedMaxUsers <= 0 ? null : parsedMaxUsers
   }
 
+  const showApiDocs = process.env.SHOW_API_DOCS !== 'false'
+
   return {
     port,
     corsOrigins,
     sessionTimeLimitSeconds,
     adminGraceSeconds,
     maxUsersPerSession,
+    showApiDocs,
   }
 }
 
@@ -47,3 +50,4 @@ logService.info(`Admin grace period: ${config.adminGraceSeconds}s`)
 if (config.maxUsersPerSession !== null) {
   logService.info(`Max users per session: ${config.maxUsersPerSession}`)
 }
+logService.info(`API Documentation: ${config.showApiDocs ? 'Enabled (/docs)' : 'Disabled'}`)

--- a/server/src/modules/shared/domain/ServerConfig.ts
+++ b/server/src/modules/shared/domain/ServerConfig.ts
@@ -4,4 +4,5 @@ export interface ServerConfig {
   sessionTimeLimitSeconds: number
   adminGraceSeconds: number
   maxUsersPerSession: number | null
+  showApiDocs: boolean
 }


### PR DESCRIPTION
### Overview
This PR introduces a new configuration setting for the server to enable or disable the API documentation (Swagger/OpenAPI). This is useful for security in production environments while keeping it enabled by default for development. It also includes a server version bump to 0.0.4.

### Key Changes
- **Server Configuration**: Added `showApiDocs` boolean to `ServerConfig` interface.
- **Environment Support**: Added `SHOW_API_DOCS` environment variable to `bin.ts`, `Dockerfile`, and `docker-compose.yml`.
- **Conditional OpenAPI**: The `@elysiajs/openapi` plugin is now conditionally loaded in `app.ts` based on the configuration.
- **Improved Logging**: Added a log message at server startup indicating if the API documentation is enabled or disabled.
- **Version Bump**: Updated `@open-retro/server` to version `0.0.4`.

### Impact
- Administrators can now hide documentation if needed.
- No breaking changes for existing deployments as it defaults to `enabled`.
- Improved traceability of server configuration at startup.